### PR TITLE
Add community guidelines (Contributing + Code of Conduct)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Code of Conduct
+
+This project aims to be a welcoming and respectful space for everyone.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Being respectful and constructive in discussions
+- Accepting feedback gracefully
+- Focusing on what is best for the community and users
+- Showing empathy and kindness to others
+
+Examples of unacceptable behavior:
+
+- Harassment, discrimination, or hateful language
+- Personal attacks, trolling, or insulting comments
+- Public or private intimidation
+- Sharing private information without explicit consent
+
+## Scope
+
+This Code of Conduct applies to all project spaces, including issues, pull
+requests, discussions, and any other community channels.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please open a private
+report by contacting the maintainer through GitHub.
+
+All reports will be reviewed and handled fairly.
+
+## Enforcement
+
+Project maintainers are responsible for clarifying and enforcing our standards.
+They may remove, edit, or reject comments, commits, code, wiki edits, issues,
+and other contributions that do not align with this Code of Conduct.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing
+
+Thanks for your interest in improving this project.
+
+## Development setup
+
+1. Fork the repository and clone your fork.
+2. Install dependencies:
+
+```bash
+yarn install
+```
+
+3. Generate docs and start development:
+
+```bash
+yarn docs:generate
+yarn dev
+```
+
+## Before opening a pull request
+
+Please run:
+
+```bash
+yarn docs:check
+yarn typecheck
+yarn lint
+yarn test
+yarn build
+```
+
+## Pull request guidelines
+
+- Keep changes focused and small
+- Add or update tests when behavior changes
+- Update documentation when needed
+- Use clear commit messages
+
+By contributing, you agree to follow the Code of Conduct.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ yarn test
 yarn build
 ```
 
+### Community
+
+- [Contributing guide](./CONTRIBUTING.md)
+- [Code of Conduct](./CODE_OF_CONDUCT.md)
+
 ### Documentation generation
 
 `/documentation` and its task-first API pages are generated from the installed


### PR DESCRIPTION
This PR adds CONTRIBUTING.md and CODE_OF_CONDUCT.md, and links them from README to clarify contribution expectations and improve project onboarding.